### PR TITLE
Tweaked the JSP value colours

### DIFF
--- a/BlueForest.xml
+++ b/BlueForest.xml
@@ -2083,6 +2083,16 @@
         <option name="ERROR_STRIPE_COLOR" />
       </value>
     </option>
+    <option name="JSP_ATTRIBUTE_VALUE">
+      <value>
+        <option name="FOREGROUND" value="50f050" />
+        <option name="BACKGROUND" />
+        <option name="FONT_TYPE" value="0" />
+        <option name="EFFECT_COLOR" />
+        <option name="EFFECT_TYPE" value="0" />
+        <option name="ERROR_STRIPE_COLOR" />
+      </value>
+    </option>
     <option name="JSP_DIRECTIVE_BACKGROUND">
       <value>
         <option name="FOREGROUND" />


### PR DESCRIPTION
The jsp values were almost invisible when selected in the previous colour. I can't change the selection colour as that's in general and so would change it for all languages, therefore I've just changed the colour of the jsp value text.
