### PR TITLE
Display Python decorators with another color

### DIFF
--- a/BlueForest.xml
+++ b/BlueForest.xml
@@ -3405,7 +3405,7 @@
     </option>
     <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" />
+        <option name="FOREGROUND" value="91ccff" />
         <option name="BACKGROUND" />
         <option name="FONT_TYPE" value="0" />
         <option name="EFFECT_COLOR" />


### PR DESCRIPTION
Python decorators were shown white-text and I changed it to blue-ish color.
