### PR TITLE
Adopted for IntelliJ15

### DIFF
--- a/BlueForest.icls
+++ b/BlueForest.icls
@@ -1,7 +1,9 @@
-<scheme name="BlueForest" version="124" parent_scheme="Default">
+<scheme name="BlueForest" version="142" parent_scheme="Default">
   <option name="LINE_SPACING" value="1.1" />
   <option name="EDITOR_FONT_SIZE" value="12" />
-  <option name="EDITOR_FONT_NAME" value="Panic Sans" />
+  <option name="CONSOLE_FONT_NAME" value="Menlo" />
+  <option name="CONSOLE_FONT_SIZE" value="13" />
+  <option name="EDITOR_FONT_NAME" value="Monaco" />
   <colors>
     <option name="ADDED_LINES_COLOR" value="8080" />
     <option name="ANNOTATIONS_COLOR" value="8080ff" />
@@ -9,6 +11,11 @@
     <option name="CARET_COLOR" value="ffffff" />
     <option name="CARET_ROW_COLOR" value="1b2b40" />
     <option name="CONSOLE_BACKGROUND_KEY" value="141f2e" />
+    <option name="FILESTATUS_ADDED" value="7fe19b" />
+    <option name="FILESTATUS_MODIFIED" value="dec233" />
+    <option name="FILESTATUS_UNKNOWN" value="d1504f" />
+    <option name="FILESTATUS_addedOutside" value="4ee650" />
+    <option name="FILESTATUS_modifiedOutside" value="f4eeaa" />
     <option name="GUTTER_BACKGROUND" value="141f2e" />
     <option name="INDENT_GUIDE" value="273e5c" />
     <option name="LINE_NUMBERS_COLOR" value="808080" />
@@ -25,18 +32,12 @@
     <option name="ABSTRACT_CLASS_NAME_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
-    <option name="ABSTRACT_METHOD_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
+    <option name="ABSTRACT_METHOD_ATTRIBUTES" baseAttributes="METHOD_CALL_ATTRIBUTES" />
     <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="fffab1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ANNOTATION_NAME_ATTRIBUTES">
@@ -46,16 +47,10 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="ANONYMOUS_CLASS_NAME_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
     <option name="ATTR_INTERNAL_CALL_ID">
       <value>
         <option name="BACKGROUND" value="a2cff5" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Annotation">
@@ -67,378 +62,309 @@
     <option name="BAD_CHARACTER">
       <value>
         <option name="BACKGROUND" value="f05050" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="BASH.EXTERNAL_COMMAND">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="BASH.HERE_DOC">
       <value>
-        <option name="BACKGROUND" value="e7ffb3" />
-        <option name="EFFECT_TYPE" value="0" />
+        <option name="BACKGROUND" value="1d3b50" />
       </value>
     </option>
     <option name="BASH.INTERNAL_COMMAND">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
-    <option name="BASH.REDIRECTION">
+    <option name="BASH.VAR_USE">
       <value>
-        <option name="FOREGROUND" value="5a5a5a" />
-        <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="BASH.SHEBANG">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
+        <option name="FOREGROUND" value="fffab1" />
       </value>
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="800000" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="BUILDOUT.KEY">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="BUILDOUT.LINE_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="BUILDOUT.SECTION_NAME">
       <value>
         <option name="FOREGROUND" value="ffffff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="BUILDOUT.VALUE">
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />
         <option name="BACKGROUND" value="ffdcdc" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Block comment">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Build-in Bash command">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CLASS_NAME_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="BACKGROUND" value="141f2e" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.BAD_CHARACTER">
       <value>
         <option name="BACKGROUND" value="f05050" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.BLOCK_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.BOOLEAN">
       <value>
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.CLASS_NAME">
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.ESCAPE_SEQUENCE">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXISTENTIAL">
       <value>
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.FUNCTION">
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.FUNCTION_BINDING">
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.FUNCTION_NAME">
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.HEREDOC_CONTENT">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.HEREDOC_ID">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.HEREGEX_CONTENT">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.HEREGEX_ID">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.IDENTIFIER">
       <value>
         <option name="FOREGROUND" value="fffab1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.JAVASCRIPT_CONTENT">
       <value>
         <option name="FOREGROUND" value="83a6c1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.JAVASCRIPT_ID">
       <value>
         <option name="FOREGROUND" value="83a6c1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.LINE_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.NUMBER">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.OBJECT_KEY">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.PROTOTYPE">
       <value>
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.REGULAR_EXPRESSION_CONTENT">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.REGULAR_EXPRESSION_FLAG">
       <value>
         <option name="FOREGROUND" value="fffab1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.REGULAR_EXPRESSION_ID">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.STRING">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.STRING_LITERAL">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="COFFEESCRIPT.THIS">
       <value>
         <option name="FOREGROUND" value="fffab1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_OUTPUT">
       <value>
         <option name="FOREGROUND" value="8080ff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="80ffff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CONSOLE_GRAY_OUTPUT">
       <value>
         <option name="FOREGROUND" value="a0a0a0" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CONSOLE_GREEN_OUTPUT">
       <value>
         <option name="FOREGROUND" value="80ff80" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CONSOLE_MAGENTA_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff80ff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CONSOLE_NORMAL_OUTPUT">
+      <value />
+    </option>
+    <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="EFFECT_TYPE" value="0" />
+        <option name="BACKGROUND" value="273e5c" />
       </value>
     </option>
     <option name="CONSOLE_RED_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CONSOLE_USER_INPUT">
       <value>
         <option name="FOREGROUND" value="ff00" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CONSOLE_YELLOW_OUTPUT">
       <value>
         <option name="FOREGROUND" value="ffff00" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CONSTRUCTOR_CALL_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="CONSTRUCTOR_DECLARATION_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CSS.COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CSS.FUNCTION">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
         <option name="FOREGROUND" value="fffab1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
@@ -451,44 +377,34 @@
     <option name="CSS.NUMBER">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="CSS.PROPERTY_VALUE">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CSS.STRING">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CSS.TAG_NAME">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CSS.URL">
       <value>
         <option name="FOREGROUND" value="fffab1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CTRL_CLICKABLE">
       <value>
-        <option name="FOREGROUND" value="ff" />
-        <option name="EFFECT_COLOR" value="ff" />
+        <option name="FOREGROUND" value="ecf364" />
+        <option name="EFFECT_COLOR" value="ecf364" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -496,223 +412,188 @@
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="BACKGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD3_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="83a6c1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD4_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CUSTOM_NUMBER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="CUSTOM_VALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="83a6c1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Class">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Clojure Atom">
       <value>
         <option name="FOREGROUND" value="83a6c1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Clojure Character">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Clojure Keyword">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
         <option name="FONT_TYPE" value="3" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Clojure Line comment">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Clojure Literal">
       <value>
         <option name="FOREGROUND" value="fffaaa" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Clojure Numbers">
       <value>
         <option name="FOREGROUND" value="fffaaa" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Clojure Strings">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
+    <option name="DEFAULT_ATTRIBUTE" baseAttributes="DEFAULT_IDENTIFIER" />
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
-    <option name="DEFAULT_BRACES">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="DEFAULT_BRACKETS">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="DEFAULT_COMMA">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
+    <option name="DEFAULT_CONSTANT" baseAttributes="DEFAULT_IDENTIFIER" />
     <option name="DEFAULT_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="DEFAULT_DOC_COMMENT_TAG">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="808080" />
-        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="DEFAULT_DOC_MARKUP">
       <value>
-        <option name="BACKGROUND" value="e2ffe2" />
-        <option name="EFFECT_TYPE" value="0" />
+        <option name="BACKGROUND" value="273e5c" />
       </value>
     </option>
-    <option name="DEFAULT_DOT">
+    <option name="DEFAULT_ENTITY" baseAttributes="DEFAULT_IDENTIFIER" />
+    <option name="DEFAULT_GLOBAL_VARIABLE">
       <value>
-        <option name="EFFECT_TYPE" value="0" />
+        <option name="FOREGROUND" value="fffab1" />
+        <option name="BACKGROUND" value="141f2e" />
       </value>
     </option>
-    <option name="DEFAULT_INVALID_STRING_ESCAPE">
+    <option name="DEFAULT_IDENTIFIER" baseAttributes="TEXT" />
+    <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="ffcccc" />
-        <option name="EFFECT_TYPE" value="0" />
+        <option name="FOREGROUND" value="fffab1" />
+        <option name="BACKGROUND" value="141f2e" />
       </value>
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
+    <option name="DEFAULT_LABEL" baseAttributes="DEFAULT_IDENTIFIER" />
     <option name="DEFAULT_LINE_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
+    <option name="DEFAULT_LOCAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="fffab1" />
+        <option name="BACKGROUND" value="141f2e" />
+      </value>
+    </option>
+    <option name="DEFAULT_METADATA" baseAttributes="TEXT" />
     <option name="DEFAULT_NUMBER">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
-    <option name="DEFAULT_OPERATION_SIGN">
+    <option name="DEFAULT_PARAMETER">
       <value>
-        <option name="EFFECT_TYPE" value="0" />
+        <option name="FOREGROUND" value="fffab1" />
+        <option name="BACKGROUND" value="141f2e" />
       </value>
     </option>
-    <option name="DEFAULT_PARENTHS">
+    <option name="DEFAULT_PREDEFINED_SYMBOL" baseAttributes="DEFAULT_IDENTIFIER" />
+    <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="EFFECT_TYPE" value="0" />
+        <option name="FOREGROUND" value="fffab1" />
+        <option name="BACKGROUND" value="141f2e" />
       </value>
     </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
+    <option name="DEFAULT_STATIC_METHOD" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
     <option name="DEFAULT_STRING">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
+    <option name="DEFAULT_TAG" baseAttributes="TEXT" />
+    <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR" baseAttributes="TEXT" />
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="83a6c1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
@@ -731,130 +612,96 @@
       <value>
         <option name="BACKGROUND" value="cc6666" />
         <option name="ERROR_STRIPE_COLOR" value="cc6666" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
         <option name="BACKGROUND" value="666666" />
         <option name="ERROR_STRIPE_COLOR" value="666666" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
         <option name="BACKGROUND" value="408040" />
         <option name="ERROR_STRIPE_COLOR" value="408040" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
         <option name="BACKGROUND" value="4d6f99" />
         <option name="ERROR_STRIPE_COLOR" value="4d6f99" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="DJANGO_ID">
       <value>
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="DJANGO_KEYWORD">
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="DJANGO_NUMBER">
       <value>
         <option name="FOREGROUND" value="f05050" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="DJANGO_STRING_LITERAL">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="DJANGO_TAG_NAME">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="DJANGO_TAG_START_END">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="DOC_COMMENT_TAG_VALUE">
-      <value>
-        <option name="FOREGROUND" value="3d3d3d" />
-        <option name="FONT_TYPE" value="3" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="DUPLICATE_FROM_SERVER">
       <value>
         <option name="BACKGROUND" value="505050" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ECMAL4.AL4.LOCAL_VARIABLE">
       <value>
         <option name="FOREGROUND" value="fffab1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="ECMAL4.ATTRIBUTE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ECMAL4.BADCHARACTER">
       <value>
         <option name="BACKGROUND" value="f05050" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ECMAL4.BLOCK_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ECMAL4.CLASS">
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ECMAL4.DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="ECMAL4.DOC_MARKUP">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ECMAL4.DOC_TAG">
@@ -867,59 +714,46 @@
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ECMAL4.GLOBAL_VARIABLE">
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="ECMAL4.INSTANCE_MEMBER_FUNCTION">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ECMAL4.INSTANCE_MEMBER_VARIABLE">
       <value>
         <option name="FOREGROUND" value="fffab1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ECMAL4.INTERFACE">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ECMAL4.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="BACKGROUND" value="f05050" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ECMAL4.KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ECMAL4.LINE_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ECMAL4.NUMBER">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ECMAL4.PARAMETER">
@@ -931,89 +765,69 @@
     <option name="ECMAL4.REGEXP">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="ECMAL4.STATIC_MEMBER_FUNCTION">
       <value>
         <option name="FOREGROUND" value="fffab1" />
         <option name="FONT_TYPE" value="3" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ECMAL4.STATIC_MEMBER_VARIABLE">
       <value>
         <option name="FOREGROUND" value="fffab1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ECMAL4.STRING">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ECMAL4.VALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="81a4bd" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="EL.BOUNDS">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="EL.BRACKETS">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="EL.IDENT">
       <value>
         <option name="FOREGROUND" value="fffab1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="EL.KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="EL.NUMBER">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="EL.PARENTHS">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="EL.STRING">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="EL_BACKGROUND">
       <value>
         <option name="BACKGROUND" value="20344d" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
+    <option name="ENUM_NAME_ATTRIBUTES" baseAttributes="CLASS_NAME_ATTRIBUTES" />
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="ff3333" />
-        <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="ERROR_STRIPE_COLOR" value="cf5b56" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
@@ -1021,7 +835,6 @@
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="BACKGROUND" value="ff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
@@ -1043,7 +856,6 @@
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
@@ -1056,48 +868,41 @@
     <option name="GQL_ID">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="GQL_INT_LITERAL">
       <value>
         <option name="FOREGROUND" value="f05050" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="GQL_KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="GQL_STRING_LITERAL">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="GString">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Groovydoc comment">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Groovydoc tag">
@@ -1111,105 +916,88 @@
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="HAML_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="HAML_FILTER">
       <value>
         <option name="FOREGROUND" value="ff8080" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value>
         <option name="BACKGROUND" value="20344d" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="HAML_ID">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="HAML_RUBY_CODE">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
         <option name="BACKGROUND" value="20344d" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="HAML_RUBY_START">
       <value>
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="HAML_TAG">
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="HAML_XHTML">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="3" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="HOCON_SUBSTITUTION_SIGN">
       <value>
         <option name="FOREGROUND" value="b8bb" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="HTML_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="HTML_TAG">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
+      <value />
     </option>
     <option name="HTML_TAG_NAME">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
@@ -1223,41 +1011,35 @@
     <option name="Here-document">
       <value>
         <option name="BACKGROUND" value="20344d" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Here-document end marker">
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Here-document start marker">
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="8080" />
         <option name="ERROR_STRIPE_COLOR" value="8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="fffab1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="INCLUDE_JAVA_CALL">
       <value>
         <option name="BACKGROUND" value="f7b891" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="INFO_ATTRIBUTES">
@@ -1267,34 +1049,25 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="INHERITED_METHOD_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
+    <option name="INHERITED_METHOD_ATTRIBUTES" baseAttributes="METHOD_CALL_ATTRIBUTES" />
     <option name="INJECTED_LANGUAGE_FRAGMENT">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
+      <value />
     </option>
     <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
       <value>
         <option name="BACKGROUND" value="ffdcd4" />
         <option name="ERROR_STRIPE_COLOR" value="f9b2b2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="fffab1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="INTERFACE_NAME_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Implicit conversion">
@@ -1309,33 +1082,28 @@
       <value>
         <option name="FOREGROUND" value="facc33" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
         <option name="FOREGROUND" value="facc33" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JAVA_BLOCK_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JAVA_DOC_MARKUP">
       <value>
         <option name="FOREGROUND" value="a000" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JAVA_DOC_TAG">
@@ -1349,7 +1117,6 @@
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="BACKGROUND" value="f05050" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JAVA_KEYWORD">
@@ -1357,58 +1124,45 @@
         <option name="FOREGROUND" value="99ff" />
         <option name="BACKGROUND" value="141f2e" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JAVA_NUMBER">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JAVA_STRING">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="83a6c1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JS.BADCHARACTER">
       <value>
         <option name="BACKGROUND" value="f05050" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JS.BLOCK_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JS.DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="JS.DOC_MARKUP">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JS.DOC_TAG">
@@ -1422,59 +1176,49 @@
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JS.GLOBAL_VARIABLE">
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JS.INSTANCE_MEMBER_FUNCTION">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
+      <value />
     </option>
     <option name="JS.INSTANCE_MEMBER_VARIABLE">
       <value>
         <option name="FOREGROUND" value="fffab1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JS.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="BACKGROUND" value="f05050" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JS.KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JS.LINE_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JS.LOCAL_VARIABLE">
       <value>
         <option name="FOREGROUND" value="fffab1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.NUMBER">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -1486,216 +1230,151 @@
     <option name="JS.REGEXP">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="JS.STATIC_MEMBER_VARIABLE">
       <value>
         <option name="FOREGROUND" value="fffab1" />
         <option name="FONT_TYPE" value="3" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JS.STRING">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JS.VALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="83a6bf" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JSP_ATTRIBUTE_NAME">
       <value>
         <option name="FOREGROUND" value="ffff66" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JSP_ATTRIBUTE_VALUE">
       <value>
         <option name="FOREGROUND" value="50f050" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="JSP_DIRECTIVE_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
         <option name="FOREGROUND" value="99ccff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
+      <value />
+    </option>
+    <option name="KOTLIN_ANNOTATION">
+      <value />
+    </option>
+    <option name="KOTLIN_MUTABLE_VARIABLE">
       <value>
-        <option name="EFFECT_TYPE" value="0" />
+        <option name="FOREGROUND" value="fffab1" />
+        <option name="BACKGROUND" value="141f2e" />
+        <option name="EFFECT_COLOR" value="0" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="Keyword">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="LINE_FULL_COVERAGE">
-      <value>
-        <option name="FOREGROUND" value="ccffcc" />
-        <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="LINE_NONE_COVERAGE">
-      <value>
-        <option name="FOREGROUND" value="ffcccc" />
-        <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="LINE_PARTIAL_COVERAGE">
-      <value>
-        <option name="FOREGROUND" value="ffffcc" />
-        <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="LIVE_TEMPLATE_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="ff0000" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LOCALE.LINE_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LOCALE.MSGCTXT_KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LOCALE.MSGID_KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LOCALE.MSGID_PLURAL_KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LOCALE.MSGSTR_KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LOCALE.MSGSTR_PLURAL_KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LOCALE.STRING_LITERAL">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LOCAL_VARIABLE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="fffab1" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="LOG_ERROR_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="LOG_EXPIRED_ENTRY">
-      <value>
-        <option name="FOREGROUND" value="555555" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="LOG_WARNING_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffa500" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LUA_COMMENT">
       <value>
         <option name="FOREGROUND" value="c0c0c0" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LUA_DEFINED_CONSTANTS">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LUA_GLOBAL_VAR">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LUA_KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LUA_LOCAL_VAR">
       <value>
         <option name="FOREGROUND" value="91cdff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="LUA_LONGCOMMENT">
       <value>
         <option name="FOREGROUND" value="c0c0c0" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LUA_LONGCOMMENT_BRACES">
       <value>
         <option name="FOREGROUND" value="c0c0c0" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LUA_LONGSTRING">
@@ -1708,14 +1387,12 @@
     <option name="LUA_LONGSTRING_BRACES">
       <value>
         <option name="FOREGROUND" value="50f050" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LUA_LUADOC">
       <value>
         <option name="FOREGROUND" value="c0c0c0" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LUA_LUADOC_TAG">
@@ -1730,124 +1407,90 @@
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LUA_NUMBER">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LUA_PARAMETER">
       <value>
         <option name="FOREGROUND" value="be9eff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="LUA_STRING">
       <value>
         <option name="FOREGROUND" value="50f050" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Line comment">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="List/map to object conversion">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
+      <value />
     </option>
     <option name="MAKO.ATTRIBUTE_NAME">
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="MAKO.ATTRIBUTE_VALUE">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="MAKO.CONTROL_STRUCTURE_ID">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="MAKO.LINE_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="MAKO.SUBSTITUTION">
       <value>
         <option name="FOREGROUND" value="81a4bd" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="MAKO.TAG">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MAKO.TAG_ID">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="MARKDOWN.ABBREVIATION">
       <value>
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.AUTO_LINK">
       <value>
         <option name="FOREGROUND" value="99ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.BLOCK_QUOTE">
       <value>
         <option name="FOREGROUND" value="83a6c1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="MARKDOWN.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="MARKDOWN.BULLET_LIST">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.CODE">
       <value>
         <option name="FOREGROUND" value="fffab1" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="MARKDOWN.DEFINITION">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.DEFINITION_TERM">
@@ -1859,134 +1502,95 @@
     <option name="MARKDOWN.EXPLICIT_LINK">
       <value>
         <option name="FOREGROUND" value="99ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.HEADER_LEVEL_1">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.HEADER_LEVEL_2">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.HEADER_LEVEL_3">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.HEADER_LEVEL_4">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.HEADER_LEVEL_5">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.HEADER_LEVEL_6">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.HRULE">
       <value>
         <option name="FOREGROUND" value="ff00ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.HTML_BLOCK">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.IMAGE">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.INLINE_HTML">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="MARKDOWN.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="MARKDOWN.LINK">
       <value>
         <option name="FOREGROUND" value="99ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.LIST_ITEM">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.MAIL_LINK">
       <value>
         <option name="FOREGROUND" value="99ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.ORDERED_LIST">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="MARKDOWN.PLAIN_TEXT">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.QUOTE">
       <value>
         <option name="FOREGROUND" value="50f050" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.REFERENCE">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.REFERENCE_LINK">
       <value>
         <option name="FOREGROUND" value="99ff" />
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="MARKDOWN.STRIKETHROUGH">
-      <value>
-        <option name="EFFECT_TYPE" value="3" />
-      </value>
-    </option>
-    <option name="MARKDOWN.TABLE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.TABLE_BODY">
@@ -1997,171 +1601,143 @@
     <option name="MARKDOWN.TABLE_HEADER">
       <value>
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MARKDOWN.VERBATIM">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="3c5f8c" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
-    <option name="METHOD_CALL_ATTRIBUTES">
+    <option name="Map key">
       <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="METHOD_DECLARATION_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
+        <option name="FOREGROUND" value="8000" />
+        <option name="BACKGROUND" value="2b2b2b" />
+        <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="NOT_USED_ELEMENT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="999999" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Number">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="OTELLO.BANG_OPERATOR">
       <value>
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="OTELLO.COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="OTELLO.CURRENCY">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="OTELLO.DATA_AMOUNT">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="OTELLO.DATA_TYPE">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="OTELLO.DECIMAL">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="OTELLO.IDENTIFIER">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="OTELLO.MMS_TYPE">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="OTELLO.NEGATIVE_FLAG">
       <value>
         <option name="FOREGROUND" value="83a6c1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="OTELLO.OBJECT_TYPE">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="OTELLO.POSITIVE_FLAG">
       <value>
         <option name="FOREGROUND" value="83a6c1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="OTELLO.PROPERTY_NAME">
       <value>
         <option name="FOREGROUND" value="fffab1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="OTELLO.SMS_TYPE">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="OTELLO.TIME_PERIOD">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="OTELLO.VOICE_TYPE">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PARAMETER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="fffab1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PHP_BAD_CHARACTER">
       <value>
         <option name="BACKGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PHP_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
       <value>
         <option name="FOREGROUND" value="f05050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PHP_DOC_COMMENT_ID">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PHP_DOC_TAG">
@@ -2175,83 +1751,62 @@
       <value>
         <option name="FOREGROUND" value="81a4bd" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PHP_HEREDOC_CONTENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PHP_IDENTIFIER">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PHP_KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="PHP_MARKUP_ID">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PHP_NUMBER">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PHP_PREDEFINED SYMBOL">
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="PHP_SCRIPTING_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PHP_STRING">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
         <option name="FOREGROUND" value="fffab1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="BACKGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PROPERTIES.KEY">
@@ -2265,26 +1820,22 @@
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PROPERTIES.VALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="83a6c1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PY.BUILTIN_NAME">
       <value>
         <option name="FOREGROUND" value="99ff" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.CLASS_DEFINITION">
@@ -2295,248 +1846,203 @@
     </option>
     <option name="PY.DECORATOR">
       <value>
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="91ccff" />
       </value>
     </option>
     <option name="PY.DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="EFFECT_TYPE" value="0" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PY.INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="BACKGROUND" value="f05050" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PY.KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="fffab1" />
       </value>
     </option>
     <option name="PY.LINE_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PY.NUMBER">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PY.PREDEFINED_DEFINITION">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PY.PREDEFINED_USAGE">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PY.SELF_PARAMETER">
       <value>
-        <option name="FOREGROUND" value="f05050" />
-        <option name="EFFECT_TYPE" value="-1" />
+        <option name="FOREGROUND" value="fffab1" />
       </value>
     </option>
     <option name="PY.STRING">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PY.STRING.B">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="PY.STRING.U">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="PY.VALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="83a6c1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="QL_ATTRIBUTE">
       <value>
         <option name="FOREGROUND" value="fffab1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="QL_DATETIME">
       <value>
         <option name="FOREGROUND" value="50f050" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="QL_ID_VARIABLE">
       <value>
         <option name="FOREGROUND" value="fffab1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="QL_KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="QL_NUMBER">
       <value>
         <option name="FOREGROUND" value="ff00" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="QL_STRING">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="REASSIGNED_LOCAL_VARIABLE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="fffab1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="REASSIGNED_PARAMETER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="fffab1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="REGEXP.BRACES">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="REGEXP.BRACKETS">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="REGEXP.PARENTHS">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="REQUIRE_GEM_CALL">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="REST.BOLD">
       <value>
         <option name="FONT_TYPE" value="3" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="REST.EXPLICIT">
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="REST.FIELD">
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="REST.FIXED">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
-      </value>
-    </option>
-    <option name="REST.INLINE">
-      <value>
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
         <option name="FOREGROUND" value="50f050" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="REST.ITALIC">
       <value>
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
     <option name="REST.LINE_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="REST.REF.NAME">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="REST.SECTION.HEADER">
       <value>
         <option name="FOREGROUND" value="99ff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RHTML_COMMENT_ID">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RHTML_EXPRESSION_END_ID">
@@ -2544,7 +2050,6 @@
         <option name="FOREGROUND" value="91ccff" />
         <option name="BACKGROUND" value="20344d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RHTML_EXPRESSION_START_ID">
@@ -2552,7 +2057,6 @@
         <option name="FOREGROUND" value="91ccff" />
         <option name="BACKGROUND" value="20344d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RHTML_OMIT_NEW_LINE_ID">
@@ -2560,13 +2064,11 @@
         <option name="FOREGROUND" value="91ccff" />
         <option name="BACKGROUND" value="20344d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RHTML_SCRIPTING_BACKGROUND_ID">
       <value>
         <option name="BACKGROUND" value="20344d" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RHTML_SCRIPTLET_END_ID">
@@ -2574,7 +2076,6 @@
         <option name="FOREGROUND" value="91ccff" />
         <option name="BACKGROUND" value="20344d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RHTML_SCRIPTLET_START_ID">
@@ -2582,110 +2083,85 @@
         <option name="FOREGROUND" value="91ccff" />
         <option name="BACKGROUND" value="20344d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_ATTR_ACCESSOR_CALL">
       <value>
         <option name="BACKGROUND" value="e8d3d3" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_ATTR_READER_CALL">
       <value>
         <option name="BACKGROUND" value="f6f6d0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_ATTR_WRITER_CALL">
       <value>
         <option name="BACKGROUND" value="d2f7d2" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_BACK_REF">
       <value>
         <option name="FOREGROUND" value="0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_BAD_CHARACTER">
       <value>
         <option name="BACKGROUND" value="f05050" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="RUBY_BRACKETS">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="RUBY_COMMA">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_CONSTANT">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_CONSTANT_DEF_ID">
       <value>
         <option name="FOREGROUND" value="660e7a" />
         <option name="FONT_TYPE" value="3" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_CVAR">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
         <option name="FONT_TYPE" value="3" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_ESCAPE_SEQUENCE">
       <value>
         <option name="FOREGROUND" value="83a6c1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_EXPR_IN_STRING">
       <value>
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_GVAR">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_HASH_ASSOC">
       <value>
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_HEREDOC_CONTENT">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_HEREDOC_ID">
@@ -2696,301 +2172,204 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="RUBY_IDENTIFIER">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
     <option name="RUBY_IMPORT_CALL">
       <value>
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_INVALID_ESCAPE_SEQUENCE">
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="BACKGROUND" value="f05050" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_IVAR">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="RUBY_LINE_CONTINUATION">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_LOCAL_VAR_ID">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="RUBY_METHOD_NAME">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_NTH_REF">
       <value>
         <option name="FOREGROUND" value="ff8080" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_NUMBER">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="RUBY_OPERATION_SIGN">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_PARAMETER_ID">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_PRIVATE_CALL">
       <value>
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_PROTECTED_CALL">
       <value>
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_PUBLIC_CALL">
       <value>
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_REGEXP">
       <value>
         <option name="BACKGROUND" value="20344d" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_REQUIRE_ARG_CALL">
       <value>
         <option name="BACKGROUND" value="ebebf5" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="RUBY_SEMICOLON">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_STRING">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_SYMBOL">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="RUBY_WORDS">
       <value>
         <option name="FOREGROUND" value="8080" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Regular expression">
       <value>
         <option name="FOREGROUND" value="ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_All production files">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_Changed Files">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_Copyright">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_Copyright MD files">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_Default">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_Generated production classes">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_Non-Project Files">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_Non-generated production files">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_Problems">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_Production">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_Production Classes">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_Project Files">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="SCOPE_KEY_Tests">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="8080" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="SMARTY_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="SMARTY_BAD_CHARACTER">
       <value>
         <option name="BACKGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="SMARTY_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="SMARTY_IDENTIFIER">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="SMARTY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="SMARTY_NUMBER">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="SMARTY_STRING">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
+      </value>
+    </option>
+    <option name="SPY-JS.EXCEPTION">
+      <value>
+        <option name="BACKGROUND" value="d1504f" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="SPY-JS.FUNCTION_SCOPE">
+      <value>
+        <option name="BACKGROUND" value="1d3b50" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="SPY-JS.PATH_LEVEL_ONE">
+      <value>
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="SPY-JS.PATH_LEVEL_TWO">
+      <value>
+        <option name="FOREGROUND" value="fffab1" />
+        <option name="BACKGROUND" value="165e90" />
+        <option name="EFFECT_COLOR" value="0" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="SPY-JS.PROGRAM_SCOPE">
+      <value>
+        <option name="BACKGROUND" value="1b2b40" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="SPY-JS.VALUE_HINT">
+      <value>
+        <option name="FOREGROUND" value="9ae6" />
+        <option name="EFFECT_COLOR" value="a9a9a9" />
       </value>
     </option>
     <option name="SQL_COLUMN">
       <value>
         <option name="FOREGROUND" value="fffab1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="SQL_KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="SQL_NUMBER">
       <value>
         <option name="FOREGROUND" value="ff00" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="SQL_STRING">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="fffab1" />
         <option name="FONT_TYPE" value="3" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
+    <option name="STATIC_FINAL_FIELD_ATTRIBUTES" baseAttributes="STATIC_FIELD_ATTRIBUTES" />
     <option name="Scala Abstract class">
       <value>
         <option name="FOREGROUND" value="91ccff" />
@@ -3000,7 +2379,6 @@
     <option name="Scala Annotation attribute name">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Annotation name">
@@ -3014,20 +2392,17 @@
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="BACKGROUND" value="f05050" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Block comment">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Class">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Immutable Collection">
@@ -3040,27 +2415,23 @@
       <value>
         <option name="FOREGROUND" value="ffffff" />
         <option name="BACKGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Keyword">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Line comment">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Local lazy val/var">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Local method call">
@@ -3071,13 +2442,11 @@
     <option name="Scala Local value">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Local variable">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Mutable Collection">
@@ -3090,90 +2459,76 @@
     <option name="Scala Number">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Object">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Parameter">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Pattern value">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Predefined types">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala String">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Template lazy val/var">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Template val">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Template var">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Trait">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Type Alias">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Type parameter">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Scala Valid escape in string">
       <value>
         <option name="FOREGROUND" value="83a6c1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ScalaDoc comment">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ScalaDoc comment tag">
@@ -3186,27 +2541,23 @@
     <option name="ScalaDoc html escape sequences">
       <value>
         <option name="FONT_TYPE" value="3" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ScalaDoc html tag">
       <value>
         <option name="FONT_TYPE" value="3" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="ScalaDoc wiki syntax elements">
       <value>
         <option name="FOREGROUND" value="aaaaaa" />
         <option name="FONT_TYPE" value="3" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Shebang (#!) comment">
       <value>
         <option name="FOREGROUND" value="8000" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Standart Java Collection">
@@ -3219,56 +2570,48 @@
       <value>
         <option name="FOREGROUND" value="f7ff66" />
         <option name="FONT_TYPE" value="3" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Static method access">
       <value>
         <option name="FOREGROUND" value="facc33" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
         <option name="FOREGROUND" value="facc33" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="String">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="String &quot;...&quot;">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="String '...'">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="TEMPLATE_VARIABLE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
         <option name="FONT_TYPE" value="3" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="TEXT">
       <value>
         <option name="FOREGROUND" value="f5f5f5" />
         <option name="BACKGROUND" value="141f2e" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
@@ -3276,7 +2619,6 @@
         <option name="FOREGROUND" value="333333" />
         <option name="BACKGROUND" value="ffff00" />
         <option name="ERROR_STRIPE_COLOR" value="ff00" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="TODO_DEFAULT_ATTRIBUTES">
@@ -3284,57 +2626,44 @@
         <option name="FOREGROUND" value="ffff" />
         <option name="FONT_TYPE" value="3" />
         <option name="ERROR_STRIPE_COLOR" value="ff" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="TWIG_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="TWIG_BAD_CHARACTER">
       <value>
         <option name="BACKGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="TWIG_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="TWIG_IDENTIFIER">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="TWIG_KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="TWIG_NUMBER">
       <value>
         <option name="FOREGROUND" value="f05050" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="TWIG_STRING">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="TYPO">
@@ -3346,7 +2675,6 @@
     <option name="UNMATCHED_BRACE_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="8c3c66" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Unresolved reference access">
@@ -3360,72 +2688,60 @@
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="VELOCITY_DIRECTIVE">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="VELOCITY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="6891cc" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="VELOCITY_NUMBER">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="VELOCITY_REFERENCE">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
+      <value />
     </option>
     <option name="VELOCITY_STRING">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Variable declaration, e.g. a=1">
       <value>
         <option name="FOREGROUND" value="fffab1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Variable use $a">
       <value>
         <option name="FOREGROUND" value="fffab1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Variable use of built-in ($PATH, ...)">
       <value>
         <option name="FOREGROUND" value="fffab1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="Variable use of composed variable like ${A}">
       <value>
         <option name="FOREGROUND" value="fffab1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
@@ -3439,139 +2755,107 @@
       <value>
         <option name="BACKGROUND" value="800080" />
         <option name="ERROR_STRIPE_COLOR" value="800080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="800080" />
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="WRONG_REFERENCES_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="ff0000" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="XML_PROLOGUE">
       <value>
         <option name="FOREGROUND" value="c0c0c0" />
         <option name="FONT_TYPE" value="3" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="XML_TAG">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value>
-        <option name="EFFECT_TYPE" value="0" />
-      </value>
+      <value />
     </option>
     <option name="XML_TAG_NAME">
       <value>
         <option name="FOREGROUND" value="91ccff" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="XPATH.KEYWORD">
       <value>
         <option name="FOREGROUND" value="99ff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="XPATH.NUMBER">
       <value>
         <option name="FOREGROUND" value="ff8080" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="XPATH.STRING">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
         <option name="FOREGROUND" value="fffab1" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="YAML_COMMENT">
       <value>
         <option name="FOREGROUND" value="50f050" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
         <option name="FOREGROUND" value="91ccff" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
         <option name="FOREGROUND" value="a0ffa0" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
         <option name="FOREGROUND" value="ffcc33" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE4">
       <value>
         <option name="BACKGROUND" value="e8d3d3" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
     <option name="YAML_TEXT">
       <value>
         <option name="FOREGROUND" value="f7ff66" />
-        <option name="EFFECT_TYPE" value="0" />
       </value>
     </option>
   </attributes>


### PR DESCRIPTION
I use this theme for my daily work and with a lot of different languages. Now I took the time to update the icls file to work with the most recent version 15 of IntelliJ IDEA. 
I also fixed a few unreadable (light background, light foreground) color combinations for some file and the unreadable changed-file colors if you use the dark theme for IntelliJ itself.