### PR TITLE
fixes #52

### DIFF
--- a/BlueForest.icls
+++ b/BlueForest.icls
@@ -1062,6 +1062,24 @@
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value />
     </option>
+    <option name="INLINE_PARAMETER_HINT">
+      <value>
+        <option name="FOREGROUND" value="939393" />
+        <option name="BACKGROUND" value="2a2a2a" />
+      </value>
+    </option>
+    <option name="INLINE_PARAMETER_HINT_CURRENT">
+      <value>
+        <option name="FOREGROUND" value="8c8c8c" />
+        <option name="BACKGROUND" value="505866" />
+      </value>
+    </option>
+    <option name="INLINE_PARAMETER_HINT_HIGHLIGHTED">
+      <value>
+        <option name="FOREGROUND" value="8c8c8c" />
+        <option name="BACKGROUND" value="404040" />
+      </value>
+    </option>
     <option name="INSPECTION_MULTIPLE_RESOLVE_WARNING_ID">
       <value>
         <option name="BACKGROUND" value="ffdcd4" />


### PR DESCRIPTION
adds colours for 'inline parameters', inverting the default luminance, offsetting it by the luminance of the blue forest background colours, and using the blue forest hue for 'highlighted'.

It looks like this:
![screenshot from 2018-04-01 22-48-43](https://user-images.githubusercontent.com/131300/38177254-e189a12a-35fe-11e8-9b5c-2aff7a0d5d38.png)
